### PR TITLE
fix: Use release asset for plugin download URL

### DIFF
--- a/wp_autoupdate.php
+++ b/wp_autoupdate.php
@@ -68,7 +68,7 @@ function self_update($transient)
         'slug' => $plugin_data['TextDomain'],
         'plugin' => $plugin_file,
         'new_version' => $new_version_number,
-        'package' => $output['zipball_url'],
+        'package' => $output['assets'][0]['browser_download_url'],
         'author' => $plugin_data['Author'],
     ];
 
@@ -136,7 +136,7 @@ function self_plugin_details($def, $action, $args)
         'description' => $plugin_data['Description'],
         'changelog' => isset($release['body']) ? $parsedown->text($release['body']) : 'No changelog available.',
     ];
-    $plugin_info->download_link = $release['zipball_url'];
+    $plugin_info->download_link = $release['assets'][0]['browser_download_url'];
 
     return $plugin_info;
 }


### PR DESCRIPTION
Fixes plugin update issues caused by inconsistent folder names

Previously, the GitHub-generated source code zip URL was used for plugin
downloads. This resulted in inconsistent plugin folder names after
updates, as GitHub alters the folder name in source code zips

This commit changes the download URL to use release assets instead.
Release assets ensure a consistent plugin folder name from the uploaded
zip

**Requires manual action:** A user or GitHub Action must now upload a
zip file of the plugin as a release asset.# Please enter the commit
message for your changes
