### PR TITLE
refactor(autoupdate): improve structure and add caching to updater

### DIFF
--- a/wp_autoupdate.php
+++ b/wp_autoupdate.php
@@ -1,152 +1,177 @@
 <?php
-
-include "Parsedown.php";
-
-/**
- * Auto updater file for the Pentangle Google Reviews plugin.
- *
- * This file handles checking for updates on GitHub and providing update details
- * when requested by WordPress.
- */
-
-add_filter('pre_set_site_transient_update_plugins', 'self_update');
-
-/**
- * Check for updates to this plugin.
- *
- * @param object $transient Transient object for update plugins.
- *
- * @return object Transient object for update plugins.
- */
-function self_update($transient)
-{
-
-    if (! is_object($transient)) {
-        $transient = new stdClass();
-    }
-
-    if (empty($transient->response) || ! is_array($transient->response)) {
-        $transient->response = [];
-    }
-
-    $plugin_file = 'pentangle-google-reviews/pentangle-google-reviews.php';
-
-    if (! function_exists('get_plugin_data')) {
-        require_once ABSPATH . 'wp-admin/includes/plugin.php';
-    }
-    $plugin_data = get_plugin_data(WP_PLUGIN_DIR . '/' . $plugin_file);
-
-    $response = wp_remote_get(
-        'https://api.github.com/repos/Pentangle/pentangle-google-reviews/releases/latest',
-        [
-            'headers' => [
-                'Authorization' => 'token ' . GITHUB_ACCESS_TOKEN,
-                'User-Agent' => 'WordPress',
-                'Accept' => 'application/vnd.github.v3+json',
-            ]
-        ]
-    );
-
-    if (is_wp_error($response)) {
-        return $transient;
-    }
-
-    $output = json_decode(wp_remote_retrieve_body($response), true);
-    if (isset($output['status']) && $output['status'] === '404') {
-        return $transient; // No release found
-    }
-
-    $new_version_number = str_replace('v', '', $output['tag_name']);
-    $is_update_available = version_compare($plugin_data['Version'], $new_version_number, '<');
-
-    if (! $is_update_available) {
-        return $transient; // No update available
-    }
-
-    $update_array = [
-        'id' => $plugin_file,
-        'slug' => $plugin_data['TextDomain'],
-        'plugin' => $plugin_file,
-        'new_version' => $new_version_number,
-        'package' => $output['assets'][0]['browser_download_url'],
-        'author' => $plugin_data['Author'],
-    ];
-
-    $transient->response[$plugin_file] = (object) $update_array;
-
-    return $transient;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
-add_filter('plugins_api', 'self_plugin_details', 10, 3);
+// Include the Parsedown library if not already loaded.
+if ( ! class_exists( 'Parsedown' ) ) {
+	include_once plugin_dir_path( __FILE__ ) . 'Parsedown.php';
+}
 
 /**
- * Provide plugin information for the update details modal.
- *
- * @param mixed  $def    The default response.
- * @param string $action The type of information being requested.
- * @param object $args   Arguments containing the plugin slug.
- *
- * @return object The plugin details or the default response.
+ * Pentangle Google Reviews Plugin Update Handler.
  */
-function self_plugin_details($def, $action, $args)
-{
-    if ($action !== 'plugin_information') {
-        return $def;
-    }
 
-    $plugin_file = 'pentangle-google-reviews/pentangle-google-reviews.php';
+add_filter( 'pre_set_site_transient_update_plugins', 'pentangle_google_reviews_update_check' );
+add_filter( 'plugins_api', 'pentangle_google_reviews_plugin_details', 10, 3 );
+add_action( 'admin_head', 'pentangle_google_reviews_changelog_styles' );
 
-    if (! function_exists('get_plugin_data')) {
-        require_once ABSPATH . 'wp-admin/includes/plugin.php';
-    }
-    $plugin_data = get_plugin_data(WP_PLUGIN_DIR . '/' . $plugin_file);
+/**
+ * Retrieve the latest release from GitHub.
+ *
+ * @return array|false Latest release data as an associative array, or false on error.
+ */
+function pentangle_google_reviews_get_latest_release(): bool|array {
+	$transient_key  = 'pgr_latest_release';
+	$cached_release = get_transient( $transient_key );
 
-    // Make sure the request matches our plugin
-    if ($args->slug !== $plugin_data['TextDomain']) {
-        return $def;
-    }
+	if ( false !== $cached_release ) {
+		return $cached_release;
+	}
 
-    $response = wp_remote_get(
-        'https://api.github.com/repos/Pentangle/pentangle-google-reviews/releases/latest',
-        [
-            'headers' => [
-                'Authorization' => 'token ' . GITHUB_ACCESS_TOKEN,
-                'User-Agent' => 'WordPress',
-                'Accept' => 'application/vnd.github.v3+json',
-            ]
-        ]
-    );
+	$api_url = 'https://api.github.com/repos/Pentangle/pentangle-google-reviews/releases/latest';
+	$headers = [
+		'Authorization' => 'token ' . GITHUB_ACCESS_TOKEN,
+		'User-Agent'    => 'WordPress',
+		'Accept'        => 'application/vnd.github.v3+json',
+	];
 
-    if (is_wp_error($response)) {
-        return $def;
-    }
+	$response = wp_remote_get( $api_url, [ 'headers' => $headers ] );
 
-    $parsedown = new Parsedown();
-    $release = json_decode(wp_remote_retrieve_body($response), true);
+	if ( is_wp_error( $response ) ) {
+		return false;
+	}
 
-    $plugin_info = new stdClass();
-    $plugin_info->name = $plugin_data['Name'];
-    $plugin_info->slug = $plugin_data['TextDomain'];
-    $plugin_info->version = str_replace('v', '', $release['tag_name']);
-    $plugin_info->author = $plugin_data['Author'];
-    $plugin_info->tested = '6.7.2';
-    $plugin_info->requires_php = '7.1';
-    $plugin_info->last_updated = $release['created_at'];
-    $plugin_info->sections = [
-        'description' => $plugin_data['Description'],
-        'changelog' => isset($release['body']) ? $parsedown->text($release['body']) : 'No changelog available.',
-    ];
-    $plugin_info->download_link = $release['assets'][0]['browser_download_url'];
+	$release_data = json_decode( wp_remote_retrieve_body( $response ), true );
+	if ( isset( $release_data['status'] ) && '404' === $release_data['status'] ) {
+		return false;
+	}
 
-    return $plugin_info;
+	// Cache the release data for one hour.
+	set_transient( $transient_key, $release_data, HOUR_IN_SECONDS );
+
+	return $release_data;
 }
 
-function plugin_modal_changelog_styles()
-{
-    if (is_admin()) : ?>
-        <style>
-            #section-changelog { display: inline-block !important; }
-        </style>
-<?php endif;
+/**
+ * Get plugin header data.
+ *
+ * @return array Plugin data.
+ */
+function pentangle_google_reviews_get_plugin_data(): array {
+	$plugin_file = 'pentangle-google-reviews/pentangle-google-reviews.php';
+
+	if ( ! function_exists( 'get_plugin_data' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	return get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin_file );
 }
-add_action('admin_head', 'plugin_modal_changelog_styles');
+
+/**
+ * Check for plugin updates.
+ *
+ * @param object $transient Data on plugin updates.
+ *
+ * @return object Updated transient object.
+ */
+function pentangle_google_reviews_update_check( object $transient ): object {
+	if ( ! is_object( $transient ) ) {
+		$transient = new stdClass();
+	}
+
+	if ( empty( $transient->response ) || ! is_array( $transient->response ) ) {
+		$transient->response = [];
+	}
+
+	$plugin_file  = 'pentangle-google-reviews/pentangle-google-reviews.php';
+	$plugin_data  = pentangle_google_reviews_get_plugin_data();
+	$release_data = pentangle_google_reviews_get_latest_release();
+
+	if ( ! $release_data ) {
+		return $transient;
+	}
+
+	$latest_version = str_replace( 'v', '', $release_data['tag_name'] );
+	if ( ! version_compare( $plugin_data['Version'], $latest_version, '<' ) ) {
+		return $transient;
+	}
+
+	if ( ! isset( $release_data['assets'][0]['browser_download_url'] ) ) {
+		return $transient;
+	}
+
+	$update_info                         = [
+		'id'          => $plugin_file,
+		'slug'        => $plugin_data['TextDomain'],
+		'plugin'      => $plugin_file,
+		'new_version' => $latest_version,
+		'package'     => $release_data['assets'][0]['browser_download_url'],
+		'author'      => $plugin_data['Author'],
+	];
+	$transient->response[ $plugin_file ] = (object) $update_info;
+
+	return $transient;
+}
+
+/**
+ * Provide up-to-date plugin details for the update information modal.
+ *
+ * @param mixed $def Default API response.
+ * @param string $action The requested action.
+ * @param object $args Plugin API arguments.
+ *
+ * @return object Plugin details or default response if conditions are not met.
+ */
+function pentangle_google_reviews_plugin_details( mixed $def, string $action, object $args ): object {
+	if ( 'plugin_information' !== $action ) {
+		return $def;
+	}
+
+	$plugin_data = pentangle_google_reviews_get_plugin_data();
+
+	if ( $args->slug !== $plugin_data['TextDomain'] ) {
+		return $def;
+	}
+
+	$release_data = pentangle_google_reviews_get_latest_release();
+	if ( ! $release_data ) {
+		return $def;
+	}
+
+	$parsedown      = new Parsedown();
+	$latest_version = str_replace( 'v', '', $release_data['tag_name'] );
+
+	$plugin_info               = new stdClass();
+	$plugin_info->name         = $plugin_data['Name'];
+	$plugin_info->slug         = $plugin_data['TextDomain'];
+	$plugin_info->version      = $latest_version;
+	$plugin_info->author       = $plugin_data['Author'];
+	$plugin_info->tested       = '6.7.2';
+	$plugin_info->requires_php = '7.0';
+	$plugin_info->last_updated = $release_data['created_at'];
+	$plugin_info->sections     = [
+		'description' => $plugin_data['Description'],
+		'changelog'   => isset( $release_data['body'] ) ? $parsedown->text( $release_data['body'] ) : 'No changelog available.',
+	];
+
+	if ( isset( $release_data['assets'][0]['browser_download_url'] ) ) {
+		$plugin_info->download_link = $release_data['assets'][0]['browser_download_url'];
+	}
+
+	return $plugin_info;
+}
+
+/**
+ * Output custom CSS for the changelog modal.
+ */
+function pentangle_google_reviews_changelog_styles(): void {
+	if ( ! is_admin() ) {
+		return;
+	}
+	echo '<style>
+        #section-changelog {
+            display: inline-block !important;
+        }
+    </style>';
+}


### PR DESCRIPTION
This commit refactors the `wp_autoupdate.php` script for the Pentangle Google Reviews plugin to improve code organization, readability, and performance.

- Renamed and prefixed functions for clarity and consistency
- Extracted core logic into separate functions
- Introduced transient caching for the GitHub API response to reduce requests
- Added standard WordPress `ABSPATH` check to prevent direct file access
- Conditionally require `Parsedown.php` library
- Added PHP type hints to function signatures and return types
- Minor update to required PHP version for plugin